### PR TITLE
Fix version string

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.3
+current_version = 0.0.4
 commit = True
 tag = False
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="valleydeight",
-    version='0.0.3',
+    version='0.0.4',
     author="Ben Krikler",
     author_email="b.krikler@gmail.com",
     description="Effective dictionary and nested object validation",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="valleydeight",
-    version="version='0.0.3'",
+    version="0.0.3",
     author="Ben Krikler",
     author_email="b.krikler@gmail.com",
     description="Effective dictionary and nested object validation",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="valleydeight",
-    version="0.0.3",
+    version='0.0.3',
     author="Ben Krikler",
     author_email="b.krikler@gmail.com",
     description="Effective dictionary and nested object validation",

--- a/valleydeight/__init__.py
+++ b/valleydeight/__init__.py
@@ -8,4 +8,4 @@ from .base import Pass
 
 
 __author__ = "Ben Krikler"
-__version__ = '0.0.3'
+__version__ = '0.0.4'


### PR DESCRIPTION
Using bumpversion had caused a problem with the version string which ruined the deployment to pypi.  Should be fixed now.